### PR TITLE
fix: Content shape for hit testing

### DIFF
--- a/Sources/Cepheus/CepheusKeyboard.swift
+++ b/Sources/Cepheus/CepheusKeyboard.swift
@@ -675,10 +675,7 @@ struct CepheusKeyboardSingleKeyRowView: View {
               inputPinyin = CepheusKeyboardAddLetter(key, textField: inputPinyin, cursor: cursor-pinyinLocation)
             }
           }, label: {
-            ZStack {
-              RoundedRectangle(cornerRadius: 3)
-                .opacity(0.0100000002421438702673861521)
-                .foregroundStyle(.gray)
+            Group {
               if letterIsCapital { //If uppercased, then letters will be displayed in capital.
                 Text(key)
                   .textCase(.uppercase)
@@ -687,6 +684,7 @@ struct CepheusKeyboardSingleKeyRowView: View {
                   .textCase(.lowercase)
               }
             }
+            .contentShape(Rectangle())
           })
           .frame(width: screenWidth/keySpaceDividedNumber)
           .accessibilityAddTraits(.isKeyboardKey)

--- a/Sources/Cepheus/CepheusPinyin.swift
+++ b/Sources/Cepheus/CepheusPinyin.swift
@@ -54,6 +54,7 @@ struct CepheusPiyin: View {
                 Image(systemName: "chevron.compact.left")
                   .padding(.trailing, 5)
               })
+              .contentShape(Rectangle())
             }
             Spacer()
             ForEach(pinyinTab*6..<pinyinTab*6+6, id: \.self) { character in
@@ -74,6 +75,7 @@ struct CepheusPiyin: View {
                 Text((arraySafeAccess(CepheusPinyinDictionary[onFocusPinyinSyllable] ?? [onFocusPinyinSyllable], element: character) ?? invalidPinyinReturn(onFocusPinyinSyllable, character: character)) as! String)
                   .padding(.horizontal, 1)
               })
+              .contentShape(Rectangle())
               .opacity((arraySafeAccess(CepheusPinyinDictionary[onFocusPinyinSyllable] ?? [onFocusPinyinSyllable], element: character) == nil) ? 0 : 1)
               .disabled(arraySafeAccess(CepheusPinyinDictionary[onFocusPinyinSyllable] ?? [onFocusPinyinSyllable], element: character) == nil)
             }
@@ -85,6 +87,7 @@ struct CepheusPiyin: View {
                 Image(systemName: "chevron.compact.right")
                   .padding(.leading, 5)
               })
+              .contentShape(Rectangle())
             }
           }
         } else {


### PR DESCRIPTION
Add `contentShape` to adjust hit testing shape, thus we can also remove hidden background for keys.